### PR TITLE
Alguns ajustes que eu acredito serem importantes.

### DIFF
--- a/Exponenciacao.c
+++ b/Exponenciacao.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
+
+#ifdef _WIN32
 #include <conio.h>
+#endif
+
 #include "Lista.h"
 #include "Exponenciacao.h"
 
@@ -16,13 +20,15 @@ void welcome(char *ch) //funcionando perfeitamente
 		"\nEste programa foi desenvolvido por Eron Fernandes e Jefferson Santos. \n"
 	);
 
-	*ch = getch();
+	*ch = getchar();
 
 	while(*ch != '1' && *ch != '2' && *ch != '3' && *ch != '4')
 	{
+#ifdef _WIN32
 		fflush(stdin);
+#endif
 		printf("\nSelecione uma opcao valida: ");
-		*ch = getch();
+		*ch = getchar();
 	}
 }
 
@@ -31,11 +37,15 @@ Lista* definirBase(void) //funcionando perfeitamente
 {
 	Lista *base;
 	int num;
+
 	printf("\nEscolha o valor da Base: \n");
 	scanf("%d", &num);
+
 	while(num < 0)
 	{
+#ifdef _WIN32
 		fflush(stdin);
+#endif
 		printf(
 			"\n\tWARNING!\n"
 			"A Base deve ter um valor positivo.\n"
@@ -57,7 +67,9 @@ int definirExpoente(void) //funcionando perfeitamente
 
 	while(expoente < 0)
 	{
+#ifdef _WIN32
 		fflush(stdin);
+#endif
 		printf(
 			"\n\tWARNING!\n"
 			"O Expoente deve ter um valor positivo.\n"
@@ -111,7 +123,11 @@ void menu(Lista *base, int *expoente, Lista *resultado) //funcionando perfeitame
 			printf("Menu Switch Error\n");
 			break;
 	}
+#ifdef _WIN32
 	system("cls");
+#else
+	system("clear");
+#endif
 	menu(base, expoente, resultado);
 }
 

--- a/Exponenciacao.c
+++ b/Exponenciacao.c
@@ -6,126 +6,130 @@
 
 void welcome(char *ch) //funcionando perfeitamente
 {
-    printf("\nBem vindo a \"Smart Calculator\", a calculadora de potencias ilimitadas! \n");
-    printf("\nSelecione o que deseja fazer: \n\n");
-    printf("1 - Definir valor da Base \n");
-    printf("2 - Definir valor do Expoente \n");
-    printf("3 - Mostrar resultado da potenciacao \n");
-    printf("4 - Sair \n");
-    printf("\nEste programa foi desenvolvido por Eron Fernandes e Jefferson Santos. \n");
+	printf(
+		"\nBem vindo a \"Smart Calculator\", a calculadora de potencias ilimitadas! \n"
+		"\nSelecione o que deseja fazer: \n\n"
+		"1 - Definir valor da Base \n"
+		"2 - Definir valor do Expoente \n"
+		"3 - Mostrar resultado da potenciacao \n"
+		"4 - Sair \n"
+		"\nEste programa foi desenvolvido por Eron Fernandes e Jefferson Santos. \n"
+	);
 
-    *ch = getch();
+	*ch = getch();
 
-    while(*ch != '1' && *ch != '2' && *ch != '3' && *ch != '4')
-    {
-        fflush(stdin);
-        printf("\nSelecione uma opcao valida: ");
-        *ch = getch();
-    }
+	while(*ch != '1' && *ch != '2' && *ch != '3' && *ch != '4')
+	{
+		fflush(stdin);
+		printf("\nSelecione uma opcao valida: ");
+		*ch = getch();
+	}
 }
 
 //case 1
 Lista* definirBase() //funcionando perfeitamente
 {
-    Lista *base;
-    int num;
-    printf("\n");
-    printf("Escolha o valor da Base: \n");
-    scanf("%d", &num);
-    while(num < 0)
-    {
-        fflush(stdin);
-        printf("\n");
-        printf("\tWARNING!\n");
-        printf("A Base deve ter um valor positivo.\n");
-        printf("Escolha o valor da Base: \n");
-        scanf("%d", &num);
-    }
-    base = numero_para_lista(num);
-    return base;
+	Lista *base;
+	int num;
+	printf("\nEscolha o valor da Base: \n");
+	scanf("%d", &num);
+	while(num < 0)
+	{
+		fflush(stdin);
+		printf(
+			"\n\tWARNING!\n"
+			"A Base deve ter um valor positivo.\n"
+			"Escolha o valor da Base: \n"
+		);
+		scanf("%d", &num);
+	}
+	base = numero_para_lista(num);
+	return base;
 }
 
 //case 2
 int definirExpoente() //funcionando perfeitamente
 {
-    int expoente;
-    printf("\n");
-    printf("Escolha o valor do Expoente: \n");
-    scanf("%d", &expoente);
+	int expoente;
+	printf("\n");
+	printf("Escolha o valor do Expoente: \n");
+	scanf("%d", &expoente);
 
-    while(expoente < 0)
-    {
-        fflush(stdin);
-        printf("\n");
-        printf("\tWARNING!\n");
-        printf("O Expoente deve ter um valor positivo.\n");
-        printf("Escolha o valor do Exooente: \n");
-        scanf("%d",&expoente);
-    }
-    return expoente;
+	while(expoente < 0)
+	{
+		fflush(stdin);
+		printf(
+			"\n\tWARNING!\n"
+			"O Expoente deve ter um valor positivo.\n"
+			"Escolha o valor do Exooente: \n"
+		);
+		scanf("%d",&expoente);
+	}
+	return expoente;
 }
 
 //case 3
 void executarPotenciacao(Lista *base, int *expoente, Lista *resultado)
 {
-    if(*expoente < 0 || tamanho(base) == 0)
-    {
-        printf("Para efetuar a potenciacao, voce deve escolher primeiro os valores da Base e do Expoente. \n");
-        printf("Tente novamente.\n");
-        return;
-    }
-    resultado = potenciacao(base, *expoente);
-    printf("\nResultado: ");
-    imprimir(resultado);
+	if(*expoente < 0 || tamanho(base) == 0)
+	{
+		printf(
+			"Para efetuar a potenciacao, voce deve escolher primeiro os valores da Base e do Expoente.\n"
+			"Tente novamente.\n"
+		);
+		return;
+	}
+	resultado = potenciacao(base, *expoente);
+	printf("\nResultado: ");
+	imprimir(resultado);
 
-    printf("\n");
-    printf("Para calcular uma nova potencia, pressione qualquer tecla. \n");
-    getch();
+	printf("\nPara calcular uma nova potencia, pressione qualquer tecla.\n");
+	getch();
 }
 
 void menu(Lista *base, int *expoente, Lista *resultado) //funcionando perfeitamente
 {
-    char ch;
+	char ch;
 
-    welcome(&ch);
+	welcome(&ch);
 
-    switch(ch)
-    {
-        case '1':
-            base = definirBase();
-            break;
-        case '2':
-            *expoente = definirExpoente();
-            break;
-        case '3':
-            executarPotenciacao(base, expoente, resultado);
-            break;
-        case '4':
-            exit(0);
-            break;
-        default:
-            printf("Menu Switch Error\n");
-            break;
-    }
-    system("cls");
-    menu(base, expoente, resultado);
+	switch(ch)
+	{
+		case '1':
+			base = definirBase();
+			break;
+		case '2':
+			*expoente = definirExpoente();
+			break;
+		case '3':
+			executarPotenciacao(base, expoente, resultado);
+			break;
+		case '4':
+			exit(0);
+			break;
+		default:
+			printf("Menu Switch Error\n");
+			break;
+	}
+	system("cls");
+	menu(base, expoente, resultado);
 }
 
 Lista * numero_para_lista(int n) // funcionando perfeitamente
 {
-    Lista *resultado = criar();
-    if(n == 0)
-        inserir_primeiro(resultado,0);
-    else
-    {
-        while(n>0)
-        {
-            inserir_primeiro(resultado,n%10);
-            n = n/10;
-        }
-    }
+	Lista *resultado = criar();
+	if(n == 0)
+		inserir_primeiro(resultado,0);
+	else
+	{
+		while(n>0)
+		{
+			inserir_primeiro(resultado,n%10);
+			n = n/10;
+		}
+	}
 
-    return resultado;
+	return resultado;
 }
 
 Lista * somar(Lista *operando1, Lista *operando2) //funcionando perfeitamente
@@ -136,31 +140,31 @@ Lista * somar(Lista *operando1, Lista *operando2) //funcionando perfeitamente
 	int tam2 = tamanho(operando2);
 	Lista *resultadoSoma = criar();
 
-    // caso os operandos sejam de tamanhos distintos, completa-se com zeros no inicio.
+	// caso os operandos sejam de tamanhos distintos, completa-se com zeros no inicio.
 	if(tam1 > tam2){
-        for(i = 0; i < tam1-tam2; i++)
-            inserir_primeiro(operando2, 0);
+		for(i = 0; i < tam1-tam2; i++)
+			inserir_primeiro(operando2, 0);
 	}
-    // caso os operandos sejam de tamanhos distintos, completa-se com zeros no inicio.
+	// caso os operandos sejam de tamanhos distintos, completa-se com zeros no inicio.
 	if(tam2 > tam1){
-        for(i = 0; i < tam2-tam1; i++)
-            inserir_primeiro(operando1, 0);
-    }
+		for(i = 0; i < tam2-tam1; i++)
+			inserir_primeiro(operando1, 0);
+	}
 
-    // soma do ultimo algarismo até o primeiro
-    // colocando as unidades no resultado e somando a dezena na proxima soma.
+	// soma do ultimo algarismo até o primeiro
+	// colocando as unidades no resultado e somando a dezena na proxima soma.
 	tam1 = tamanho(operando1);
 
 	while(tam1 > 0){
-	    valor = ler_pos(operando1, tam1-1) + ler_pos(operando2, tam1-1) + valor/10 ;
-	    inserir_primeiro(resultadoSoma, valor%10);
-        tam1--;
+		valor = ler_pos(operando1, tam1-1) + ler_pos(operando2, tam1-1) + valor/10 ;
+		inserir_primeiro(resultadoSoma, valor%10);
+		tam1--;
 	}
 
-    // caso sobre uma dezena da soma do primeiro algarismo, ela é adicionada no inicio do numero.
+	// caso sobre uma dezena da soma do primeiro algarismo, ela é adicionada no inicio do numero.
 	if(valor/10 > 0)
-        inserir_primeiro(resultadoSoma, valor/10);
-    return resultadoSoma;
+		inserir_primeiro(resultadoSoma, valor/10);
+	return resultadoSoma;
 }
 
 Lista * listaXnum(Lista * l, int n) // funcionando perfeitamente
@@ -169,9 +173,9 @@ Lista * listaXnum(Lista * l, int n) // funcionando perfeitamente
 	int valor = 0; // resultado da multiplicação de 'n' por um valor da lista
 	int tam;
 
-    // multiplica 'n' por toda a lista 'l'
+	// multiplica 'n' por toda a lista 'l'
 	for(tam = tamanho(l); tam > 0; tam--)
-    {
+	{
 		valor = n*ler_pos(l, tam-1) + valor/10;     //valor é um numero de dois digitos
 		inserir_primeiro(resultadoMult, valor%10);  // insere a unidade no final
 	}
@@ -185,40 +189,40 @@ Lista * listaXnum(Lista * l, int n) // funcionando perfeitamente
 
 Lista * listaXlista(Lista *operando1, Lista *operando2) // funcionando perfeitamente
 {
-    int tam2 = tamanho(operando2);
-    int i,j;
-    Lista *resultado1 = criar();
-    Lista *resultado2;
-    Lista *lixo;
+	int tam2 = tamanho(operando2);
+	int i,j;
+	Lista *resultado1 = criar();
+	Lista *resultado2;
+	Lista *lixo;
 
-    for(j = 0; tam2 > 0; j++, tam2--)
-    {
-        resultado2 = listaXnum(operando1, ler_pos(operando2, tam2-1));
-        for(i = 0; i<j ;i++)
-        {
-            inserir_ultimo(resultado2, 0);
-        }
-        // como o resultado1 sempre vai pegar um valor de soma e vai perder o caminho para a lista original
-        // a variavel "lixo" sempre pega os endereços perdidos e destrói.
-        lixo = resultado1;
-        resultado1 = somar(resultado1, resultado2);
-        destruir(lixo);
-    }
+	for(j = 0; tam2 > 0; j++, tam2--)
+	{
+		resultado2 = listaXnum(operando1, ler_pos(operando2, tam2-1));
+		for(i = 0; i<j ;i++)
+		{
+			inserir_ultimo(resultado2, 0);
+		}
+		// como o resultado1 sempre vai pegar um valor de soma e vai perder o caminho para a lista original
+		// a variavel "lixo" sempre pega os endereços perdidos e destrói.
+		lixo = resultado1;
+		resultado1 = somar(resultado1, resultado2);
+		destruir(lixo);
+	}
 
-    return resultado1;
+	return resultado1;
 }
 
 Lista * potenciacao(Lista *base, int expoente) // funcionando perfeitamente
 {
-    Lista *resultado;
-    int i;
+	Lista *resultado;
+	int i;
 
-    resultado = base;
+	resultado = base;
 
-    for(i=1; i<expoente; i++)
-    {
-        resultado = listaXlista(resultado, base);
-    }
-    return resultado;
+	for(i=1; i<expoente; i++)
+	{
+		resultado = listaXlista(resultado, base);
+	}
+	return resultado;
 }
 

--- a/Exponenciacao.c
+++ b/Exponenciacao.c
@@ -27,7 +27,7 @@ void welcome(char *ch) //funcionando perfeitamente
 }
 
 //case 1
-Lista* definirBase() //funcionando perfeitamente
+Lista* definirBase(void) //funcionando perfeitamente
 {
 	Lista *base;
 	int num;
@@ -48,7 +48,7 @@ Lista* definirBase() //funcionando perfeitamente
 }
 
 //case 2
-int definirExpoente() //funcionando perfeitamente
+int definirExpoente(void) //funcionando perfeitamente
 {
 	int expoente;
 	printf("\n");

--- a/Exponenciacao.c
+++ b/Exponenciacao.c
@@ -3,6 +3,8 @@
 
 #ifdef _WIN32
 #include <conio.h>
+#else
+#include <unistd.h>
 #endif
 
 #include "Lista.h"
@@ -20,7 +22,11 @@ void welcome(char *ch) //funcionando perfeitamente
 		"\nEste programa foi desenvolvido por Eron Fernandes e Jefferson Santos. \n"
 	);
 
-	*ch = getchar();
+#ifdef _WIN32
+	*ch = getch();
+#else
+	scanf("%c", ch);
+#endif
 
 	while(*ch != '1' && *ch != '2' && *ch != '3' && *ch != '4')
 	{
@@ -28,7 +34,11 @@ void welcome(char *ch) //funcionando perfeitamente
 		fflush(stdin);
 #endif
 		printf("\nSelecione uma opcao valida: ");
-		*ch = getchar();
+#ifdef _WIN32
+		*ch = getch();
+#else
+		scanf("%c", ch);
+#endif
 	}
 }
 
@@ -94,8 +104,17 @@ void executarPotenciacao(Lista *base, int *expoente, Lista *resultado)
 	printf("\nResultado: ");
 	imprimir(resultado);
 
+#ifdef _WIN32
 	printf("\nPara calcular uma nova potencia, pressione qualquer tecla.\n");
-	getchar();
+	getch();
+#else
+	printf(
+		"\nPara calcular uma nova potencia, pressione Enter(e aguarde 3 segundos).\n"
+		"(Ou no caso de haver algo em stdin, aguarde 3 segundos...)\n"
+	);
+	do { getchar(); } while (getchar() != '\n');
+	sleep(3);
+#endif
 }
 
 void menu(Lista *base, int *expoente, Lista *resultado) //funcionando perfeitamente

--- a/Exponenciacao.c
+++ b/Exponenciacao.c
@@ -61,8 +61,7 @@ Lista* definirBase(void) //funcionando perfeitamente
 int definirExpoente(void) //funcionando perfeitamente
 {
 	int expoente;
-	printf("\n");
-	printf("Escolha o valor do Expoente: \n");
+	printf("\nEscolha o valor do Expoente: \n");
 	scanf("%d", &expoente);
 
 	while(expoente < 0)

--- a/Exponenciacao.c
+++ b/Exponenciacao.c
@@ -96,7 +96,7 @@ void executarPotenciacao(Lista *base, int *expoente, Lista *resultado)
 	imprimir(resultado);
 
 	printf("\nPara calcular uma nova potencia, pressione qualquer tecla.\n");
-	getch();
+	getchar();
 }
 
 void menu(Lista *base, int *expoente, Lista *resultado) //funcionando perfeitamente

--- a/Exponenciacao.h
+++ b/Exponenciacao.h
@@ -3,8 +3,8 @@
 
 void menu(Lista *base, int *expoente, Lista *resultado);
 void welcome(char *ch);
-Lista* definirBase();
-int definirExpoente();
+Lista* definirBase(void);
+int definirExpoente(void);
 void executarPotenciacao(Lista *base, int *expoente, Lista *resultado);
 Lista* numero_para_lista(int n);
 Lista* somar(Lista *operando1, Lista *operando2);

--- a/Exponenciacao.h
+++ b/Exponenciacao.h
@@ -1,3 +1,5 @@
+#ifndef _EXPO_H
+#define _EXPO_H
 
 void menu(Lista *base, int *expoente, Lista *resultado);
 void welcome(char *ch);
@@ -9,3 +11,5 @@ Lista* somar(Lista *operando1, Lista *operando2);
 Lista* listaXnum(Lista * l, int n);
 Lista* listaXlista(Lista *operando1, Lista *operando2);
 Lista* potenciacao(Lista *base, int expoente);
+
+#endif /* _EXPO_H */

--- a/Lista.c
+++ b/Lista.c
@@ -38,7 +38,7 @@ void inverter(Lista *l)
 }
 
 
-Lista * criar()
+Lista * criar(void)
 {
 	Lista * l = (Lista *)malloc(sizeof(Lista));
 	l->ini = NULL;

--- a/Lista.c
+++ b/Lista.c
@@ -19,22 +19,22 @@ struct no
 
 void inverter(Lista *l)
 {
-    int i, tam = tamanho(l);
-    No* aux;
-    No* aux2 = NULL;
-    l->fim = l->ini;
+	int i, tam = tamanho(l);
+	No* aux;
+	No* aux2 = NULL;
+	l->fim = l->ini;
 
-    if(tam = 0)
-        return;
+	if(tam = 0)
+		return;
 
-    for(i=0; i<tam-1; i++)
-    {
-        aux = l->ini;
-        l->ini = aux->prox;
-        aux->prox = aux2;
-        aux2 = aux;
-    }
-    l->ini->prox = aux;
+	for(i=0; i<tam-1; i++)
+	{
+		aux = l->ini;
+		l->ini = aux->prox;
+		aux->prox = aux2;
+		aux2 = aux;
+	}
+	l->ini->prox = aux;
 }
 
 
@@ -59,7 +59,7 @@ void limpar(Lista * l)
 {
 	No * aux = l->ini;
 	while (aux != NULL)
-    {
+	{
 		No * aux2 = aux;
 		aux = aux->prox;
 		free(aux2);
@@ -74,7 +74,7 @@ void imprimir(Lista * l)
 	No * aux = l->ini;
 	printf("[ ");
 	while (aux != NULL)
-    {
+	{
 		printf("%d ", aux->info);
 		aux = aux->prox;
 	}
@@ -96,7 +96,7 @@ int ler_pos(Lista * l, int p)
 	int i;
 	No * aux = l->ini;
 	if (p < 0 || p >= tamanho(l))
-    {
+	{
 		printf("Posicao invalida!\n");
 		return -1;
 	}
@@ -120,15 +120,15 @@ int buscar(Lista * l, int v)
 {
 	int p = 0;
 	No * aux = l->ini;
-/*
-	for (i=0; i<tamanho(l); i++) {
-		if (ler_pos(l,i) == v) {
-			return i;
-		}
-	}
-*/
+	/*
+	   for (i=0; i<tamanho(l); i++) {
+	   if (ler_pos(l,i) == v) {
+	   return i;
+	   }
+	   }
+	 */
 	while (aux != NULL && aux->info != v)
-    {
+	{
 		aux = aux->prox;
 		p++;
 	}
@@ -141,7 +141,7 @@ void escrever_pos(Lista * l, int p, int v)
 	int i;
 	No * aux = l->ini;
 	if (p < 0 || p >= tamanho(l))
-    {
+	{
 		printf("Posicao invalida!\n");
 		return;
 	}
@@ -157,7 +157,7 @@ void inserir_pos(Lista * l, int p, int v)
 	No * aux = l->ini, * aux2;
 
 	if (p < 0 || p > tamanho(l))
-    {
+	{
 		printf("Posicao invalida!\n");
 		return;
 	}
@@ -166,15 +166,15 @@ void inserir_pos(Lista * l, int p, int v)
 	aux2->info = v;
 	aux2->prox = NULL;
 	if (p > 0 && p < l->tam)
-    {
+	{
 		for (i=0; i<p-1; i++)
-            aux = aux->prox;
+			aux = aux->prox;
 
 		aux2->prox = aux->prox;
 		aux->prox = aux2;
 	}
 	else
-    {
+	{
 		if (p == 0)
 		{
 			aux2->prox = l->ini;
@@ -185,7 +185,7 @@ void inserir_pos(Lista * l, int p, int v)
 			if (l->fim != NULL)
 				l->fim->prox = aux2;
 
-            l->fim = aux2;
+			l->fim = aux2;
 		}
 	}
 
@@ -208,7 +208,7 @@ int remover_pos(Lista * l, int p)
 	No * aux = l->ini, * aux2;
 
 	if (p < 0 || p >= tamanho(l))
-    {
+	{
 		printf("Posicao invalida!\n");
 		return;
 	}
@@ -221,7 +221,7 @@ int remover_pos(Lista * l, int p)
 		aux->prox = aux2->prox;
 	}
 	else
-    {
+	{
 		aux = NULL;
 		aux2 = l->ini;
 		l->ini = aux2->prox;

--- a/Lista.c
+++ b/Lista.c
@@ -210,7 +210,7 @@ int remover_pos(Lista * l, int p)
 	if (p < 0 || p >= tamanho(l))
 	{
 		printf("Posicao invalida!\n");
-		return;
+		return -1;
 	}
 	if (p > 0)
 	{

--- a/Lista.c
+++ b/Lista.c
@@ -24,7 +24,7 @@ void inverter(Lista *l)
 	No* aux2 = NULL;
 	l->fim = l->ini;
 
-	if(tam = 0)
+	if(tam == 0)
 		return;
 
 	for(i=0; i<tam-1; i++)

--- a/Lista.h
+++ b/Lista.h
@@ -1,3 +1,6 @@
+#ifndef _LISTA_H
+#define _LISTA_H
+
 typedef struct lista Lista;
 
 Lista * criar();
@@ -21,4 +24,4 @@ int remover_primeiro(Lista * l);
 int remover_ultimo(Lista * l);
 void remover(Lista * l, int v);
 
-
+#endif /* _LISTA_H */

--- a/Lista.h
+++ b/Lista.h
@@ -3,7 +3,7 @@
 
 typedef struct lista Lista;
 
-Lista * criar();
+Lista * criar(void);
 void destruir(Lista * l);
 void limpar(Lista * l);
 void imprimir(Lista * l);

--- a/Principal.c
+++ b/Principal.c
@@ -5,12 +5,12 @@
 
 int main()
 {
-    Lista *base;
-    Lista *resultado;
-    int *expoente = (int*) malloc(sizeof(int));
-    *expoente = -1;
+	Lista *base;
+	Lista *resultado;
+	int *expoente = (int*) malloc(sizeof(int));
+	*expoente = -1;
 
-    menu(base, expoente, resultado);
+	menu(base, expoente, resultado);
 
 	return 0;
 }

--- a/Principal.c
+++ b/Principal.c
@@ -3,7 +3,7 @@
 #include "Lista.h"
 #include "Exponenciacao.h"
 
-int main()
+int main(void)
 {
 	Lista *base;
 	Lista *resultado;


### PR DESCRIPTION
Incluem mudanças de chamada de, por exemplo, `getch()` e `fflush()`, que só devem estar presentes no Windows.

`fflush()` tem comportamento indefinido em outros sistemas. O seu papel é limpar tudo que ainda resta em uma stream de arquivo, porém não é bem assim que funciona. É possível imitar o seu comportamento lendo toda uma stream até se encontrar `EOF`, menos para a stream `stdin`(entrada do console), que chega até `'\n'` e depois pede para o usuário inserir algo.

Algo parecido com isso:

``` C
#include <stdio.h>

void
fflushstub(FILE *stream)
{
    while (!feof(stream))
        fgetc(stream);
}
```

---

Quanto aos comandos de preprocessador, como `#ifdef _WIN32`: essas linhas criam ramificações que código que aparecerão somente quando um macro estiver definido. O macro `_WIN32` é normalmente definido pelo compilador, quando se trata de um compilador para o Windows.

P.S.: Preferência do caramba, mas **indentação é com tabulação**.
